### PR TITLE
#8: Fixed CVE-2020-8908 by excluding guava dependency

### DIFF
--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -5,3 +5,7 @@ Code name: Initial release
 ## Features / Enhancements
 
 * #6: Added the initial implementation
+
+## Bug Fixes
+
+* #8: Fixed CVE-2020-8908 by excluding guava dependency

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
+            <exclusions>
+                <!-- excluded since it introduces CVE-2020-8908 -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Closes #8